### PR TITLE
fix: scripts' unary operator errors

### DIFF
--- a/scripts/build-static-lib-openssl.sh
+++ b/scripts/build-static-lib-openssl.sh
@@ -57,7 +57,7 @@ function check_env() {
 #
 function get_last_openssl_release() {
     echo -e "\n================ Get last release ================\n"
-    local FUNC_EXIT_CODE
+    local FUNC_EXIT_CODE=0
 
     # Get last release tag
     LAST_RELEASE=$(git ls-remote --tags "https://github.com/openssl/openssl.git" | \

--- a/scripts/build-static-lib-pcre2.sh
+++ b/scripts/build-static-lib-pcre2.sh
@@ -57,7 +57,7 @@ function check_env() {
 #
 function get_last_pcre2_release() {
     echo -e "\n================ Get last release ================\n"
-    local FUNC_EXIT_CODE
+    local FUNC_EXIT_CODE=0
 
     # Get last release tag
     LAST_RELEASE=$(git ls-remote --heads --tags "https://github.com/PCRE2Project/pcre2.git" | \

--- a/scripts/build-static-lib-zlib.sh
+++ b/scripts/build-static-lib-zlib.sh
@@ -57,7 +57,7 @@ function check_env() {
 #
 function get_last_zlib_release() {
     echo -e "\n================ Get last release ================\n"
-    local FUNC_EXIT_CODE
+    local FUNC_EXIT_CODE=0
 
     # Get last release tag
     LAST_RELEASE=$(git ls-remote --heads --tags "https://github.com/madler/zlib.git" | \


### PR DESCRIPTION
Description:
- Fix the errors related to unary operator in bash. This was caused by non assigning a value when declaring a local variable to get the error codes inside functions